### PR TITLE
Add missing AGENTS.md to project root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Agent Instructions
+
+This document provides guidance for AI agents working on the
+`class-action-sentinel` project. It defines domain boundaries, general
+instructions, and programmatic checks to ensure alignment with the project's
+vision and standards.
+
+## Domain Boundaries
+
+Agents should focus on tasks that advance the functional aspects of the
+`class-action-sentinel` project:
+
+- **Data Ingestion and Parsing**: Developing and refining systems that ingest
+  and parse legal data, including court filings and legal notices.
+- **Monitoring and Alerting**: Implementing systems to monitor court filings and
+  send alerts based on predefined criteria.
+- **Case Tracking**: Building tools to track the progress of class-action cases.
+- **Documentation**: Maintaining and updating project documentation, including
+  `README.md`, `GOAL.md`, and `STANDARDS.md`.
+
+## General Instructions
+
+All agents must adhere to the project standards defined in `STANDARDS.md`:
+
+- **Code Quality**: Ensure all code passes linting (`eslint`, `markdownlint`) and
+  is formatted correctly (`prettier`).
+- **Testing**: Maintain a minimum of 80% test coverage for new code. All
+  existing tests must pass.
+- **Security**: Never commit secrets or sensitive data. Follow best practices
+  for data protection and dependency management.
+- **Review**: Perform self-reviews and ensure all changes are well-documented.
+
+## Programmatic Checks
+
+Before submitting any changes, agents must run the following checks:
+
+- **Linting**: `npm run lint` (or equivalent markdown/code linters).
+- **Formatting**: `npm run format`.
+- **Testing**: `npm test` to ensure all tests pass and coverage is maintained.
+
+If any of these checks fail, agents must resolve the issues before proceeding
+with submission.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to the `class-action-sentinel` project will be documented
+in this file.
+
+## [Unreleased]
+
+### Added
+
+- `AGENTS.md`: New file to provide guidance and domain boundaries for AI agents.
+- `CHANGELOG.md`: This file, to track project changes.
+- Updated `README.md` to reference `AGENTS.md`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # class-action-sentinel
+
+## Documentation for Agents
+
+If you are an AI agent working on this project, please refer to the
+[AGENTS.md](AGENTS.md) file for domain boundaries, general instructions, and
+programmatic checks.


### PR DESCRIPTION
Added `AGENTS.md` to the project root to define domain boundaries and provide guidance for AI agents working on the `class-action-sentinel` project. The content was tailored to the project's domain (legal data parsing, monitoring, and tracking). Additionally, updated `README.md` to point agents to the new document and initialized `CHANGELOG.md` to document these changes, fulfilling the Definition of Done.

Fixes #2

---
*PR created automatically by Jules for task [17674772497993557735](https://jules.google.com/task/17674772497993557735) started by @username-anthony-is-not-available*